### PR TITLE
Fix camera controls in MRWT mode

### DIFF
--- a/WebVis/src/GUI.js
+++ b/WebVis/src/GUI.js
@@ -96,8 +96,12 @@ window._toggleMRWTMode = function() {
         showAllModules();
     }
     
-    // Toggle camera movement
-    gwUser.controls.enabled = !window._isMRWTModeActive;
+    // // Toggle camera movement
+    // gwUser.controls.enabled = !window._isMRWTModeActive;
+    // Enable only panning, disable other controls
+    gUser.controls.enablePan = true;     // Enable panning (right/middle-click + drag)
+    gUser.controls.enableRotate = false; // Disable rotation (left-click + drag)
+    gUser.controls.enableZoom = false;   // Disable zooming (scroll wheel)
 }
 
 let _exampleLoaders = {};


### PR DESCRIPTION
- Enable panning but disable rotation and zooming in MRWT mode
- Use existing OrbitControls instead of reimplementing camera translation
- Set orthographic projection when entering MRWT mode
- Restore module visibility when exiting MRWT mode

Closes #102